### PR TITLE
Remove extra query to database. (Fixes #43)

### DIFF
--- a/fal/models/season.py
+++ b/fal/models/season.py
@@ -36,12 +36,8 @@ class Season(Base):
         current_season = query.one_or_none()
 
         if not current_season:
-            new_season = Season(season_of_year=season_of_year, year=year)
-            print(f'Adding {new_season} to database')
-            session.add(new_season)
+            current_season = Season(season_of_year=season_of_year, year=year)
+            session.add(current_season)
             session.commit()
-            query = session.query(Season).filter(
-                Season.season_of_year == season_of_year, Season.year == year)
-            current_season = query.one()
 
         return current_season

--- a/fal/models/team.py
+++ b/fal/models/team.py
@@ -35,11 +35,6 @@ class Team(Base):
             team = Team(name=name, season_id=season.id)
             session.add(team)
             session.commit()
-            query = session.query(Team).filter(
-                Team.name == name,
-                Team.season_id == season.id
-            )
-            team = query.one()
 
         return team
 

--- a/test/unit/test_load_teams/test_load_teams.py
+++ b/test/unit/test_load_teams/test_load_teams.py
@@ -127,7 +127,7 @@ def test_add_anime_to_team(session, season_factory, team_factory, anime_factory)
 @patch('fal.controllers.load_teams.config')
 @patch('fal.controllers.load_teams.session_scope')
 def test_load_teams(session_scope_mock, config_mock, shared_datadir, session_scope, session, anime_factory, season_factory):
-    season = season_factory(id=1)
+    season = season_factory(id=0)
 
     def mock_config_getitem(key):
         assert key == "season info"
@@ -155,7 +155,7 @@ def test_load_teams(session_scope_mock, config_mock, shared_datadir, session_sco
     with (shared_datadir / 'anime.txt').open() as f:
         all_anime = f.readlines()
     for anime_name in all_anime:
-        anime_factory(name=anime_name.strip(), eligible=1, season=season)
+        anime_factory(name=anime_name.strip(), eligible=1)
 
     with (shared_datadir / 'registration.txt').open() as f:
         registration_data = f.readlines()


### PR DESCRIPTION
Turns out we don't need to requery the database. Once we commit, sqlalchemy populates the id field for us.