### PR TITLE
move session binding code to session fixture

### DIFF
--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,7 +1,11 @@
+import contextlib
+
 from pytest_factoryboy import register
 import pytest
 import factories
-import contextlib
+import sqlalchemy
+
+import fal.models
 
 register(factories.SeasonFactory)
 register(factories.AnimeFactory)
@@ -10,6 +14,10 @@ register(factories.TeamFactory)
 
 @pytest.fixture
 def session():
+    engine = sqlalchemy.create_engine('sqlite://')
+    fal.models.Base.metadata.create_all(engine)
+    factories.session_factory.configure(bind=engine)
+
     _session = factories.session_factory()
     yield _session
     _session.rollback()

--- a/test/unit/factories/session.py
+++ b/test/unit/factories/session.py
@@ -1,8 +1,3 @@
 from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy import create_engine
 
-import fal.models
-
-engine = create_engine('sqlite://')
-fal.models.Base.metadata.create_all(engine)
-session_factory = scoped_session(sessionmaker(bind=engine))
+session_factory = scoped_session(sessionmaker())


### PR DESCRIPTION
I attempted to follow https://factoryboy.readthedocs.io/en/latest/orms.html#managing-sessions but since we use `pytest` and not `unittest` I couldn't really follow it exactly.

After messing around I got the tests to pass in #41 but as of right now I DON'T KNOW WHY THIS WORKS. I'll do more research into how these scoped_sessions work but for now this should unblock #41 