### PR TITLE
Added import of annotations from future to teams views

### DIFF
--- a/fal/views/teams.py
+++ b/fal/views/teams.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import configparser
 


### PR DESCRIPTION
I saw that this was in all of the files in the controllers directory, so I added it to views/teams.py. I guess it's not really needed since there are no forward type references, but I thought we might want it for consistency.