### PR TITLE
Fixed score per favorite to 75 for week 14

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -27,7 +27,7 @@ highest-unique : 4000
     5 : 25
     8 : 50
     11 : 75
-    14 : 100
+    14 : 75
 
     [scoring.simulcast]
     # week : score for simulcast


### PR DESCRIPTION
The [rules](https://myanimelist.net/forum/?topicid=1801940) say "+75 points for each user who has favorited the anime upon week 11 and at the end of the FAL season (week 14)." I guess it got changed back from last season.